### PR TITLE
Fixed temp and RH null issues

### DIFF
--- a/lib/Screens/DataPages/CurrentDataPretty.dart
+++ b/lib/Screens/DataPages/CurrentDataPretty.dart
@@ -186,7 +186,8 @@ class _CurrentDataPrettyState extends State<CurrentDataPretty>
                         Flexible(
                             child: Padding(
                           padding: const EdgeInsets.all(5.0),
-                          child: Text(
+                          child: (snapshot.data!.airTemperature != null)
+                          ?Text(
                             'Air Temperature: ${snapshot.data!.airTemperature!.toStringAsFixed(2)}°F',
                             softWrap: false,
                             style: TextStyle(
@@ -195,12 +196,15 @@ class _CurrentDataPrettyState extends State<CurrentDataPretty>
                                 color: Theme.of(context)
                                     .colorScheme
                                     .onPrimaryFixed),
-                          ),
+                          )
+                          : Text('Temperature N/A'),
+
                         )),
                         Flexible(
                             child: Padding(
                           padding: const EdgeInsets.all(5.0),
-                          child: Text(
+                          child:(snapshot.data!.relativeHumidity != null)
+                           ? Text(
                             'Relative Humidity: ${snapshot.data!.relativeHumidity!.toStringAsFixed(2)}%',
                             softWrap: false,
                             style: TextStyle(
@@ -209,7 +213,8 @@ class _CurrentDataPrettyState extends State<CurrentDataPretty>
                                 color: Theme.of(context)
                                     .colorScheme
                                     .onPrimaryFixed),
-                          ),
+                          )
+                          : Text('Humidity N/A'),
                         )),
                       ],
                     ),


### PR DESCRIPTION
Latest temperature or RH being down would cause my display not to load due to a null value. Added a null check in build to avoid the issue. Currently displays Temperature N/A or Humidity N/A respectively. 